### PR TITLE
Fix the conversion of the remove operation

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -222,12 +222,7 @@ export class Client extends React.Component {
 
         const currentDoc = this.docSet.getDoc(this.props.docId)
         const docNew = Automerge.change(currentDoc, `Client ${this.props.clientId}`, doc => {
-          // Approach 1 which uses the difference between two Automerge documents
-          // to calculate the operations.
-          // applyImmutableDiffOperations(doc, differences)
-
-          // Approach 2 which directly uses the Slate operations to modify the
-          // Automerge document.
+          // Use the Slate operations to modify the Automerge document.
           applySlateOperations(doc, operations)
         })
 


### PR DESCRIPTION
If the object that the remove operation refers to is NOT in Slate, just modify the temporary object.
If the object that the remove operation refers to is in Slate, create an operation to remove said object.